### PR TITLE
[ROUTING] Keep Sensor Module route permanent after refresh

### DIFF
--- a/sceval_frontend/src/routes/RouteDeclarations.tsx
+++ b/sceval_frontend/src/routes/RouteDeclarations.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { Route, Redirect } from 'react-router-dom';
+import { LeftNav } from '../components/LeftNav';
 import { Login, ResetPassword, Register, Hardware, 
-  EmailSent, MyAccount, AddSensorModule } from '../containers/index';
+  EmailSent, MyAccount, AddSensorModule, SensorModule } from '../containers/index';
 export interface RouteDeclarationsProps {
   isSavedLoginPresent: boolean;
   isLoggedIn: boolean;
@@ -121,9 +122,9 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
           path="/sensor_modules/:id"
           component={() => (
             <>
-              <Hardware
+              <LeftNav />
+              <SensorModule
                 isLoggedIn={this.props.isLoggedIn}
-                onLogIn={this.props.onLogin}
               />
             </>
           )}


### PR DESCRIPTION
We do not want to redirect to `/devices` from `/sensorModule:id` after refresh, so I created some logic that will allow for this. 