### PR TITLE
Quite removing "index.html" at build

### DIFF
--- a/sceval_frontend/Dockerfile
+++ b/sceval_frontend/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:latest as build-stage
+FROM node:12.9.0-alpine as build-stage
 
 RUN mkdir -p /usr/src/sceval
 # set working directory
@@ -12,7 +12,7 @@ COPY . /usr/src/sceval
 # create production build
 RUN npm run-script build:production
 # start app
-FROM nginx:alpine
+FROM nginx:1.17.3-alpine
 
 COPY --from=build-stage /usr/src/sceval/build/ /usr/share/nginx/html
 COPY --from=build-stage /usr/src/sceval/nginx.conf /etc/nginx/conf.d/default.conf

--- a/sceval_frontend/nginx.conf
+++ b/sceval_frontend/nginx.conf
@@ -1,8 +1,6 @@
 server {
     listen       80;
     server_name  0.0.0.0;
-    #charset koi8-r;
-    #access_log  /var/log/nginx/host.access.log  main;
 
     location / {
         root   /usr/share/nginx/html;
@@ -10,6 +8,7 @@ server {
         try_files $uri /index.html;
     }
 
+    # TODO make 404 page
     #error_page  404              /404.html;
 
     # redirect server error pages to the static page /50x.html
@@ -18,27 +17,4 @@ server {
     location = /50x.html {
         root   /usr/share/nginx/html;
     }
-
-    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
-    #
-    #location ~ \.php$ {
-    #    proxy_pass   http://127.0.0.1;
-    #}
-
-    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
-    #
-    #location ~ \.php$ {
-    #    root           html;
-    #    fastcgi_pass   127.0.0.1:9000;
-    #    fastcgi_index  index.php;
-    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
-    #    include        fastcgi_params;
-    #}
-
-    # deny access to .htaccess files, if Apache's document root
-    # concurs with nginx's one
-    #
-    #location ~ /\.ht {
-    #    deny  all;
-    #}
 }

--- a/sceval_frontend/package.json
+++ b/sceval_frontend/package.json
@@ -31,7 +31,7 @@
     "eject": "react-scripts eject",
     "start-js": "sh -ac '. ./.env; react-scripts-ts start'",
     "start": "npm-run-all -p watch-css start-js",
-    "build-js": "react-scripts-ts build && rm build/index.html",
+    "build-js": "react-scripts-ts build",
     "build": "npm-run-all build-css build-js",
     "build-env": "sh -ac '. ./.env; npm run build'",
     "build:production": "REACT_APP_ENV=production npm run build-env",


### PR DESCRIPTION
`index.html` that is built by `create-react-app` should exists for production environment.
Nginx will serve this file at first.

And I refactor a little of related docker.