### PR TITLE
[DEVOPS] Include ES2019 library

### DIFF
--- a/sceval_frontend/tsconfig.json
+++ b/sceval_frontend/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "target": "es5",
     "lib": [
+      "es2019",
       "dom",
       "dom.iterable",
       "esnext"

--- a/sceval_frontend/tsconfig.prod.json
+++ b/sceval_frontend/tsconfig.prod.json
@@ -4,7 +4,7 @@
     "outDir": "build/dist",
     "module": "amd",
     "target": "es5",
-    "lib": ["es6", "dom"],
+    "lib": ["es2019", "dom"],
     "sourceMap": true,
     "allowJs": true,
     "jsx": "react",


### PR DESCRIPTION
In order to use methods like `flat()`, we need to upgrade our library to include `es2019`.