### PR TITLE
fix routing issue which always take user to either login or devices page

### DIFF
--- a/sceval_frontend/src/App.tsx
+++ b/sceval_frontend/src/App.tsx
@@ -26,14 +26,12 @@ const App: React.FC = () => {
     return (
         <ContextProvider>
             <div className="App">
-                <Route>
-                    <RouteDeclarations
-                        onLogin={onLogin}
-                        isLoggedIn={isLoggedIn}
-                        isAuthenticated={isAuthenticated}
-                        isSavedLoginPresent={true}
-                    />
-                </Route>
+                <RouteDeclarations
+                    onLogin={onLogin}
+                    isLoggedIn={isLoggedIn}
+                    isAuthenticated={isAuthenticated}
+                    isSavedLoginPresent={true}
+                />
             </div>
         </ContextProvider>
     );

--- a/sceval_frontend/src/containers/ResetPassword.tsx
+++ b/sceval_frontend/src/containers/ResetPassword.tsx
@@ -107,7 +107,6 @@ const ResetPassword: React.FC = () => {
           )}
         </div>
       </div>
-      }
     </Fragment>
   );
 };

--- a/sceval_frontend/src/routes/RouteDeclarations.tsx
+++ b/sceval_frontend/src/routes/RouteDeclarations.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Route, Redirect } from 'react-router-dom';
+import { Route, Redirect, Switch } from 'react-router-dom';
 import { LeftNav } from '../components/LeftNav';
 import { Login, ResetPassword, Register, Hardware, 
   EmailSent, MyAccount, AddSensorModule, SensorModule } from '../containers/index';
@@ -7,8 +7,8 @@ import { RouteKeys, RouteDeclarationsProps } from '../components/entities/Routes
 
 export default class RouteDeclarations extends React.Component<RouteDeclarationsProps, any> {
   render() {
-    return [
-      (
+    return (
+      <Switch>
         <Route
           key={RouteKeys.Home}
           exact={true}
@@ -17,34 +17,6 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
             <Redirect to="/login" />
           )}
         />
-      ),
-      (
-        <Route
-          key={RouteKeys.Misc}
-          exact={true}
-          path="*"
-          component={() => {
-            if (this.props.isLoggedIn) {
-              return (
-                <>
-                  <Login
-                    isLoggedIn={this.props.isLoggedIn}
-                    onLogIn={this.props.onLogin}
-                  />
-                </>
-              );
-            } else {
-              return (
-                <Hardware
-                  isLoggedIn={this.props.isLoggedIn}
-                  onLogIn={this.props.onLogin}
-                />
-              );
-            }
-          }}
-        />
-      ),
-      (
         <Route
           key={RouteKeys.Login}
           exact={true}
@@ -58,8 +30,6 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
             </>
           )}
         />
-      ),
-      (
         <Route
           key={RouteKeys.ResetPassword}
           exact={true}
@@ -70,8 +40,6 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
             </>
           )}
         />
-      ),
-      (
         <Route
           key={RouteKeys.Register}
           exact={true}
@@ -85,8 +53,6 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
             </>
           )}
         />
-      ),
-      (
         <Route
           key={RouteKeys.EmailSent}
           exact={true}
@@ -97,8 +63,6 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
             </>
           )}
         />
-      ),
-      (
         <Route
           key={RouteKeys.Devices}
           exact={true}
@@ -112,8 +76,6 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
             </>
           )}
         />
-      ),
-      (
         <Route
           key={RouteKeys.MyAccount}
           exact={true}
@@ -127,8 +89,6 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
             </>
           )}
         />
-      ),
-      (
         <Route
           key={RouteKeys.SensorModules}
           exact={true}
@@ -142,8 +102,6 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
             </>
           )}
         />
-      ),
-      (
         <Route
           key={RouteKeys.AddSensorModule}
           exact={true}
@@ -157,7 +115,23 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
             </>
           )}
         />
-      )
-    ];
+        <Route
+          key={RouteKeys.Misc}
+          exact={true}
+          path="*"
+          component={() => {
+            if (this.props.isLoggedIn) {
+              return (
+                <Redirect to="/login" />
+              );
+            } else {
+              return (
+                <Redirect to="/devices" />
+              );
+            }
+          }}
+        />
+      </Switch>
+    );
   }
 }


### PR DESCRIPTION
I think there is an issue with the MISC route. The way it is set up, it will always either take the user to login page or devices page because it is placed at the beginning of the route array. And because the path for MISC route is set to "*", it will match all URL. This is why when we go to some other page, other than login or devices, and reload the page, we are taken back to the login or devices page. So the fix for this is
- Move the MISC route config to the bottom of the list so that it will be selected only if no other route above it is matched
- However, because the RouteDeclarations function returns an Array of routes, I think React will select ALL routes that match the URL. This means if you are on the sensor module page and reload the page, you will get Route for sensor module page AND route for Misc. So to fix this, instead of returning an Array of Routes, we return a Switch. Switch will go though all the routes and return the first route that matches the URL.