### PR TITLE
fix left nav error when the user is not logged in

### DIFF
--- a/sceval_frontend/src/components/LeftNav.tsx
+++ b/sceval_frontend/src/components/LeftNav.tsx
@@ -1,11 +1,19 @@
 import React from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink, Redirect, RouteComponentProps } from 'react-router-dom';
 // import required images
 const modeLogo = require('../common_images/mode-logo.svg');
 const hardware = require('../common_images/navigation/nav-gateway.svg');
 const profile = require('../common_images/navigation/default-avatar.svg');
 
-export const LeftNav: React.FC = () => {
+interface LeftNavProps {
+  isLoggedIn: boolean;
+}
+
+export const LeftNav: React.FC<LeftNavProps & React.Props<any>> = (props: LeftNavProps & React.Props<any>) => {
+  if (!props.isLoggedIn) {
+    return <Redirect to="/login" />;
+  }
+
   return (
     <div className="navigation-bar">
       <div className="sidebar-head">

--- a/sceval_frontend/src/containers/AddSensorModule.tsx
+++ b/sceval_frontend/src/containers/AddSensorModule.tsx
@@ -238,7 +238,6 @@ export class AddSensorModule extends Component<
   render() {
     return (
       <Fragment>
-        <LeftNav />
         <div className="scan-container">
           <div className="page-header">Add Sensor Modules</div>
           <div className="scan-section">

--- a/sceval_frontend/src/containers/Hardware.tsx
+++ b/sceval_frontend/src/containers/Hardware.tsx
@@ -436,7 +436,6 @@ const Hardware = withRouter((props: HardwareProps & RouteComponentProps) => {
    */
   return (
     <div>
-      <LeftNav />
       <div className="hardware-section">
         <div className="page-header">
           {selectedDevice === 0 ? (

--- a/sceval_frontend/src/containers/MyAccount.tsx
+++ b/sceval_frontend/src/containers/MyAccount.tsx
@@ -90,7 +90,6 @@ const MyAccount = withRouter(
 
     return (
       <div>
-        <LeftNav />
         <div className="account-section">
           <div className="page-header">
             <h1>My Account</h1>

--- a/sceval_frontend/src/routes/RouteDeclarations.tsx
+++ b/sceval_frontend/src/routes/RouteDeclarations.tsx
@@ -105,6 +105,7 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
           path="/devices"
           component={() => (
             <>
+              <LeftNav isLoggedIn={this.props.isLoggedIn}/>
               <Hardware
                 isLoggedIn={this.props.isLoggedIn}
                 onLogIn={this.props.onLogin}
@@ -120,6 +121,7 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
           path="/my_account"
           component={() => (
             <>
+              <LeftNav isLoggedIn={this.props.isLoggedIn}/>
               <MyAccount
                 isLoggedIn={this.props.isLoggedIn}
                 onLogIn={this.props.onLogin}
@@ -135,7 +137,7 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
           path="/sensor_modules/:deviceId/:sensorModuleId"
           component={() => (
             <>
-              <LeftNav />
+              <LeftNav isLoggedIn={this.props.isLoggedIn}/>
               <SensorModule
                 isLoggedIn={this.props.isLoggedIn}
               />
@@ -150,6 +152,7 @@ export default class RouteDeclarations extends React.Component<RouteDeclarations
           path="/devices/:deviceId/add_sensor_modules"
           component={() => (
             <>
+              <LeftNav isLoggedIn={this.props.isLoggedIn}/>
               <AddSensorModule
                 isLoggedIn={this.props.isLoggedIn}
                 onLogIn={this.props.onLogin}


### PR DESCRIPTION
If the user try to reload a page e.g. Devices or Sensor module page while he is logged out (probably from another browser tab), he will get some javascript error on the page. This is because LeftNav tries to display some user info. This fix is just adding login check and redirect the user to the login page if user is not logged in.