### PR TITLE
add support for custom sensor module

### DIFF
--- a/sceval_frontend/src/components/entities/SensorModule.ts
+++ b/sceval_frontend/src/components/entities/SensorModule.ts
@@ -32,15 +32,19 @@ export interface SensorModuleInterface extends Omit<KeyValueStore, 'value'> {
         // sensor module id
         id: string;
         // assoociated gateway
-        gateway: number;
+        gatewayID?: number;
+        // sensor module's model id
+        modelId?: string;
         // sensing interval
         interval: number;
         // sensing (off/on)
         sensing: string;
+        // OPTIONAL list of sensors the module has
+        moduleSchema?: Array<string>;
         // active sensors
-        sensors: Array<any>;
+        sensors: Array<string>;
         // sensor module name
-        name: string;
+        name?: string;
     };
 }
 export interface AddSensorModuleState {

--- a/sceval_frontend/src/containers/AddSensorModule.tsx
+++ b/sceval_frontend/src/containers/AddSensorModule.tsx
@@ -178,17 +178,23 @@ export class AddSensorModule extends Component<
     try {
       await Promise.all(this.state.selectedModules.map((selectedModule, index): Promise<any>[] => {
         const key: string = `${Constants.SENSOR_MODULE_KEY_PREFIX}${selectedModule.sensorModuleId}`;
-        const params: KeyValueStore = {
+        const params: SensorModuleInterface = {
           key: key,
           value: {
             id: selectedModule.sensorModuleId,
-            gatewayID: this.context.state.selectedGateway,
+            gatewayID: Number(this.context.state.selectedGateway),
             sensing: 'on',
             interval: 30,
             modelId: selectedModule.modelId,
-            sensors: selectedModule.moduleSchema
+            sensors: selectedModule.moduleSchema,
           }
         };
+
+        if (selectedModule.modelId === Constants.CUSTOM_SENSOR_MODULE_MODEL_ID) {
+          // For custom sensorm modules, add schema to the key/value store so that we have a list of sensors this
+          // sensor module support or else we won't know what sensor this module support later on
+          params.value.moduleSchema = selectedModule.moduleSchema;
+        }
 
         return [
           // associate new sensors to the home

--- a/sceval_frontend/src/containers/SensorModule.tsx
+++ b/sceval_frontend/src/containers/SensorModule.tsx
@@ -59,7 +59,7 @@ interface SensorTypeSetting {
     selected: boolean;
 }
 interface SensorModuleSettings {
-    name: string;
+    name?: string;
     sensors: SensorTypeSetting[];
 }
 
@@ -375,8 +375,14 @@ export const SensorModule = withRouter((props: SensorModuleProps & RouteComponen
             // list of all possible sensor type this module has
             allSensorTypes = sensorModel.moduleSchema;
         } else {
-            // Use the sensor module's "sensors" array as the list of possible sensor type
-            allSensorTypes = sensorModuleObj.value.sensors;
+            // If sensor module definition is not found which mean this module is probably a CUSTOM module.
+            // For CUSTOM sensor module, we store the moduleSchema in the key/value store so try to find it
+            // there first. If it is not available then use "sensors" list
+            if (sensorModuleObj.value.moduleSchema && sensorModuleObj.value.moduleSchema.length > 0) {
+                allSensorTypes = sensorModuleObj.value.moduleSchema;
+            } else {
+                allSensorTypes = sensorModuleObj.value.sensors;
+            }
         }
 
         // sort sensor types by names

--- a/sceval_frontend/src/utils/Constants.ts
+++ b/sceval_frontend/src/utils/Constants.ts
@@ -15,22 +15,7 @@ export namespace Constants {
     'discoveredSensorModules';
   export const EVENT_REALTIME_DATA: string = 'realtimeData';
   export const EVENT_TIME_SERIES_DATA: string = 'timeSeriesData';
-  /**
-   * A constant used for specifying sensor types associated with the Alps sensor module.
-   */
-  export const ALPS_SENSOR_SET: Array<string> = [
-    'TEMPERATURE:0',
-    'HUMIDITY:0',
-    'UV:0',
-    'PRESSURE:0',
-    'AMBIENT:0',
-    'MAGNETIC_X:0',
-    'ACCELERATION_Y:0',
-    'ACCELERATION_Z:0',
-    'MAGNETIC_Y:0',
-    'MAGNETIC_Z:0',
-    'ACCELERATION_X:0'
-  ];
+
    /**
     * Error messages for user-related authentication.
     */
@@ -68,6 +53,9 @@ export namespace Constants {
   export const CENTURY_IN_MS: number      = 60 * 60 * 24 * 356 * 100 * 1000;
   export const MILLENNIUM_IN_SECS: number = 60 * 60 * 24 * 356 * 1000;
   export const MILLENNIUM_IN_MS: number   = 60 * 60 * 24 * 356 * 1000 * 1000;
+
+  // The modelId of custom sensor modules
+  export const CUSTOM_SENSOR_MODULE_MODEL_ID: string = 'CUSTOM';
 }
 
  /**

--- a/sceval_frontend/src/utils/SensorTypes.ts
+++ b/sceval_frontend/src/utils/SensorTypes.ts
@@ -1,4 +1,4 @@
-import { MODULE_CATELOG } from './Constants';
+import { MODULE_CATELOG, Constants } from './Constants';
 import { SensorModuleDefinition } from '../components/entities/SensorModule';
 
 /**
@@ -139,6 +139,8 @@ export function evaluateSensorModelName (modelId: string): string {
   const discoveredModule: SensorModuleDefinition | undefined = evaluateSensorModel(modelId);
   if (discoveredModule) {
     return discoveredModule.name;
+  } else if (modelId === Constants.CUSTOM_SENSOR_MODULE_MODEL_ID) {
+    return Constants.CUSTOM_SENSOR_MODULE_MODEL_ID;
   } else {
     return '';
   }


### PR DESCRIPTION
To support custom sensor modules, we will use the module info we got from the discover sensor module message from WebSocket since we don't have these info in the catalog. When we create key/value store for the module, we will save the module's schema in the store so that we can retrieve and use it later.