### PR TITLE
change create release script to generate the correct env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To begin development off MODE's sensor cloud evaluation kit, first obtain the zi
 
 3. You must have an account with the [MODE Developer Console](https://console.tinkermode.com/console/signup).
 
-4. If you don't already have node installed, you will need to install Node. The application works with `Node 8.16.0` or `Node 10.16.0` or later version on your local development machine. If you don't already have node, please navigate [here](https://nodejs.org/en/download/) to download the source code compatible with your machine. `NPM is distributed with Node.js`, which means that when you downlaod Node.js, you automatically get npm installed on your computer.
+4. If you don't already have node installed, you will need to install Node. The application works with `Node 8.16.0` or `Node 10.16.0` or later version on your local development machine. If you don't already have node, please navigate [here](https://nodejs.org/en/download/) to download the source code compatible with your machine. `NPM is distributed with Node.js`, which means that when you download Node.js, you automatically get npm installed on your computer.
 
 ## Quick Start
 

--- a/create_sceval_release.sh
+++ b/create_sceval_release.sh
@@ -75,7 +75,7 @@ do
 done
 
 # create .env file for the developer so he doesn't need to create one but just need to fill in the values
-echo "REACT_APP_PROJECT_ID=\nREACT_APP_API_KEY=" > "${RELEASE_DIR}/.env"
+echo "REACT_APP_PROJECT_ID=\nREACT_APP_APP_ID" > "${RELEASE_DIR}/.env"
 
 # If releases directory does not exist, create it.
 mkdir -p ${ALL_RELEASES_DIR}

--- a/sceval_frontend/src/index.tsx
+++ b/sceval_frontend/src/index.tsx
@@ -8,12 +8,14 @@ import * as serviceWorker from './serviceWorker';
 
 require('dotenv').config();
 
+if (!process.env.REACT_APP_PROJECT_ID || !process.env.REACT_APP_APP_ID) {
+    throw new Error("Invalid configuration. Please make sure your environment file contain configuration for REACT_APP_PROJECT_ID and REACT_APP_APP_ID");
+}
 
 // from .env
-const projectId = process.env.REACT_APP_PROJECT_ID !== undefined ?
-    parseInt(process.env.REACT_APP_PROJECT_ID, 10) :
-    1235;
-const appId = process.env.REACT_APP_APP_ID !== undefined ? process.env.REACT_APP_APP_ID : 'sceval_app';
+const projectId = parseInt(process.env.REACT_APP_PROJECT_ID, 10);
+const appId = process.env.REACT_APP_APP_ID;
+
 AppContext.setProjectId(projectId);
 AppContext.setAppId(appId);
 


### PR DESCRIPTION
Base on the latest code, it looks like we require `REACT_APP_PROJECT_ID` and `REACT_APP_APP_ID` in the .env file so I have updated the `create_sceval_release` to generate the `.env` file with the correct variables. 

Since we are going to give this code to the customers, I have removed the hardcoded REACT_APP_PROJECT_ID and REACT_APP_APP_ID from index.tsx so that the users don't use our sceval app config. If these 2 variables are missing, they will get an error when they view the app from the browser.